### PR TITLE
Changed CURRENT_USER detection method

### DIFF
--- a/depNotify.sh
+++ b/depNotify.sh
@@ -520,7 +520,7 @@ TRIGGER="event"
   done
 
 # After the Apple Setup completed. Now safe to grab the current user and user ID
-  CURRENT_USER=$(/usr/bin/python -c 'from SystemConfiguration import SCDynamicStoreCopyConsoleUser; import sys; username = (SCDynamicStoreCopyConsoleUser(None, None, None) or [None])[0]; username = [username,""][username in [u"loginwindow", None, u""]]; sys.stdout.write(username + "\n");')
+  CURRENT_USER=$(/usr/bin/stat -f "%Su" /dev/console)
   CURRENT_USER_ID=$(id -u $CURRENT_USER)
   echo "$(date "+%a %h %d %H:%M:%S"): Current user set to $CURRENT_USER (id: $CURRENT_USER_ID)." >> "$DEP_NOTIFY_DEBUG"
 


### PR DESCRIPTION
Substituted detection of the currently logged-in user from python to bash using the stat command.  Python v2.x is deprecated since 2019, and is now throwing on-screen warnings in macOS Monterey.