### PR TITLE
Change how CURRENT_USER is detected (macOS 12 readiness)

### DIFF
--- a/depNotifyReset.sh
+++ b/depNotifyReset.sh
@@ -9,7 +9,7 @@
   rm /var/tmp/com.depnotify.*
 
 # Removing plists in local user folder
-  CURRENT_USER=$(/usr/bin/python -c 'from SystemConfiguration import SCDynamicStoreCopyConsoleUser; import sys; username = (SCDynamicStoreCopyConsoleUser(None, None, None) or [None])[0]; username = [username,""][username in [u"loginwindow", None, u""]]; sys.stdout.write(username + "\n");')
+  CURRENT_USER=$( scutil <<< "show State:/Users/ConsoleUser" | awk '/Name :/ && ! /loginwindow/ { print $3 }' )
   rm /Users/"$CURRENT_USER"/Library/Preferences/menu.nomad.DEPNotify*
 
 # Restarting cfprefsd due to plist changes


### PR DESCRIPTION
macOS Monterey readiness. Use `scutil` instead of `python` to detect current user. 
https://scriptingosx.com/2020/02/getting-the-current-user-in-macos-update/