### PR TITLE
Updated preferences flushing logic

### DIFF
--- a/depNotify.sh
+++ b/depNotify.sh
@@ -599,8 +599,14 @@ TRIGGER="event"
     DEP_NOTIFY_CONFIG_PLIST="/Users/$CURRENT_USER/Library/Preferences/menu.nomad.DEPNotify.plist"
 
   # If testing mode is on, this will remove some old configuration files
-    if [ "$TESTING_MODE" = true ] && [ -f "$DEP_NOTIFY_CONFIG_PLIST" ]; then rm "$DEP_NOTIFY_CONFIG_PLIST"; fi
-    if [ "$TESTING_MODE" = true ] && [ -f "$DEP_NOTIFY_USER_INPUT_PLIST" ]; then rm "$DEP_NOTIFY_USER_INPUT_PLIST"; fi
+    if [ "$TESTING_MODE" = true ] && [ -f "$DEP_NOTIFY_CONFIG_PLIST" ]; then defaults delete "$DEP_NOTIFY_CONFIG_PLIST"; fi
+    if [ "$TESTING_MODE" = true ] && [ -f "$DEP_NOTIFY_USER_INPUT_PLIST" ]; then defaults delete "$DEP_NOTIFY_USER_INPUT_PLIST"; fi
+    
+  # If you are frequently testing changes to the Registration screen,
+  # it may be necessary to flush the preferences out of the cache
+  # to see your changes reflected more immediately (or correctly).
+    /usr/bin/killall cfprefsd
+    sleep 1
 
   # Setting default path to the plist which stores all the user completed info
     /usr/bin/defaults write "$DEP_NOTIFY_CONFIG_PLIST" pathToPlistFile "$DEP_NOTIFY_USER_INPUT_PLIST"


### PR DESCRIPTION
Instead of 'rm' ing the preferences file, use killall cfprefsd and "defaults delete" to flush every element out of the plist file.  This is in keeping with Apple's recommended practice since Mac OS X 10.9, when cfprefsd was introduced.  

Simply deleting the file does *not* flush the preferences out of memory, and may cause conflicts.